### PR TITLE
Add initial CI/CD for project

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,14 @@
+name: Build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - run: node -v
+      - run: npm -v


### PR DESCRIPTION
This MR adds a basic CI/CD with the latest Ubuntu LTS and the latest Node LTS as well. This can be expanded in the future with testing and linting depending on this project's future.